### PR TITLE
Included stl header

### DIFF
--- a/src/util/AdaptiveRandomNeighborhood.h
+++ b/src/util/AdaptiveRandomNeighborhood.h
@@ -27,6 +27,7 @@
 #include <PseudoRandom.h>
 
 #include <vector>
+#include <algorithm>
 //#include <list>
 
 using namespace std;


### PR DESCRIPTION
jMetalCpp does not compile in Cygwin without this line
